### PR TITLE
Fixing "vicinity" field that now comes often but not always

### DIFF
--- a/googleplaces/__init__.py
+++ b/googleplaces/__init__.py
@@ -259,7 +259,7 @@ class Place(object):
         self._id = place_data['id']
         self._reference = place_data['reference']
         self._name = place_data['name']
-        self._vicinity = place_data['vicinity']
+        self._vicinity = place_data.get('vicinity','')
         self._geo_location = place_data['geometry']['location']
         self._rating = place_data.get('rating')
         self._types = place_data.get('types')


### PR DESCRIPTION
Google changed their API for returning "vicinity" just when the location search points to door number, street name, etc. When it comes with just latitude/longitude or a postcode, the vicinity doesn't return.
