### PR TITLE
add next_page_token to nearby search to fetch more results

### DIFF
--- a/googleplaces/__init__.py
+++ b/googleplaces/__init__.py
@@ -25,6 +25,7 @@ import warnings
 import lang
 import ranking
 import types
+import time
 
 
 __all__ = ['GooglePlaces', 'GooglePlacesError', 'GooglePlacesAttributeError',
@@ -59,7 +60,13 @@ def _fetch_remote(service_url, params={}, use_http_post=False):
 def _fetch_remote_json(service_url, params={}, use_http_post=False):
     """Retrieves a JSON object from a URL."""
     request_url, response = _fetch_remote(service_url, params, use_http_post)
-    return (request_url, json.load(response))
+    result = json.load(response)['results']
+    while 'next_page_token' in response.keys():
+        params['pagetoken'] = response['next_page_token']
+        time.sleep(2) #google-places api reply with INVALID_REQUEST if the requests are send too quickly
+        request_url, response = _fetch_remote(service_url, params, use_http_post)
+        result.extend(json.load(response)['results'])
+    return (request_url, result)
 
 def _fetch_remote_file(service_url, params={}, use_http_post=False):
     """Retrieves a file from a URL.


### PR DESCRIPTION
In the nearby Search google only replies with 20 results for a request. It comes with a next_page_token to fetch more results.
Also to consider here that sending multiple requests too quickly results in INVALID_REQUEST response. So added 2 second delay before sending another request.
