### PR TITLE
Use place_id, warn for id and reference, fixes #39

### DIFF
--- a/googleplaces/__init__.py
+++ b/googleplaces/__init__.py
@@ -755,8 +755,9 @@ class Place(object):
     """
     def __init__(self, query_instance, place_data):
         self._query_instance = query_instance
-        self._id = place_data['id']
-        self._reference = place_data['reference']
+        self._place_id = place_data['place_id']
+        self._id = place_data.get('id', '')
+        self._reference = place_data.get('reference', '')
         self._name = place_data.get('name','')
         self._vicinity = place_data.get('vicinity', '')
         self._geo_location = place_data['geometry']['location']
@@ -770,7 +771,10 @@ class Place(object):
 
     @property
     def reference(self):
-        """Returns contains a unique token for the place.
+        """DEPRECATED AS OF JUNE 24, 2014. May stop being returned on June 24,
+        2015. Reference: https://developers.google.com/places/documentation/search
+
+        Returns contains a unique token for the place.
 
         The token can be used to retrieve additional information about this
         place when invoking the getPlace method on an GooglePlaces instance.
@@ -778,18 +782,38 @@ class Place(object):
         You can store this token and use it at any time in future to refresh
         cached data about this Place, but the same token is not guaranteed to
         be returned for any given Place across different searches."""
+        warnings.warn('The "reference" feature is deprecated and may'
+                      'stop working any time after June 24, 2015.',
+                      FutureWarning)
         return self._reference
 
     @property
     def id(self):
-        """Returns the unique stable identifier denoting this place.
+        """DEPRECATED AS OF JUNE 24, 2014. May stop being returned on June 24,
+        2015. Reference: https://developers.google.com/places/documentation/search
+
+        Returns the unique stable identifier denoting this place.
 
         This identifier may not be used to retrieve information about this
         place, but is guaranteed to be valid across sessions. It can be used
         to consolidate data about this Place, and to verify the identity of a
         Place across separate searches.
         """
+        warnings.warn('The "id" feature is deprecated and may'
+                      'stop working any time after June 24, 2015.',
+                      FutureWarning)
         return self._id
+
+    @property
+    def place_id(self):
+        """Returns the unique stable identifier denoting this place.
+
+        This identifier may be used to retrieve information about this
+        place.
+
+        This should be considered the primary identifier of a place.
+        """
+        return self._place_id
 
     @property
     def icon(self):
@@ -907,7 +931,7 @@ class Place(object):
 
     def checkin(self):
         """Checks in an anonymous user in."""
-        self._query_instance.checkin(self.reference,
+        self._query_instance.checkin(self.place_id,
                                      self._query_instance.sensor)
 
     def get_details(self, language=None):
@@ -929,7 +953,7 @@ class Place(object):
                 except KeyError:
                     language = lang.ENGLISH
             self._details = _get_place_details(
-                    self.reference, self._query_instance.api_key,
+                    self.place_id, self._query_instance.api_key,
                     self._query_instance.sensor, language=language)
 
     @cached_property

--- a/googleplaces/tests/testfixtures.py
+++ b/googleplaces/tests/testfixtures.py
@@ -19,6 +19,7 @@ PLACES_QUERY_RESPONSE = {
          "name" : "Zaaffran Restaurant - BBQ and GRILL, Darling Harbour",
          "rating" : 3.90,
          "reference" : "CpQBjAAAAFAOaZhKjoDYfDsnISY6p4DKgdtrXTLJBhYsF0WnLBrkLHN3LdLpxc9VsbQKfbtg87nnDsl-SdCKT60Vs4Sxe_lCNCgRBxgq0JBBj8maNZ9pEp_LWjq8O-shdjh-LexdN5o-ZYLVBXhqX2az4TFvuOqme0eRirqMyatKgfn9nuKEkKR2a5tfFQlMfSZSlbyoOxIQVffhpcBqaua-_Yb364wx9xoUC1I-81Wj7aBmSmkctXv_YE7jqgQ",
+         "place_id": "ChIJfZmx2Jxw44kR11GqlDbYxxx",
          "types" : [ "restaurant", "food", "establishment" ],
          "vicinity" : "Harbourside Centre 10 Darling Drive, Darling Harbour, Sydney"
       },
@@ -34,6 +35,7 @@ PLACES_QUERY_RESPONSE = {
          "name" : "Criniti's",
          "rating" : 3.10,
          "reference" : "CmRgAAAAm4ajUz0FWaV2gB5mBbdIFhg-Jn98p1AQOrr1QxUWh7Q0nhEUhZL-hY9L4l5ifvRfGttf_gyBpSsGaxMjnr_pcPGUIQKES0vScLQpwM7jsS3BQKB83G9B_SlJFcRuD5dDEhCoNxepsgfJ5YSuXlYjVo9tGhQaKigmZ0WQul__A702AiH3WIy6-A",
+         "place_id": "ChIJfZmx2Jxw44kR11GqlDbYsss",
          "types" : [ "restaurant", "food", "establishment" ],
          "vicinity" : "231/10 Darling Dr, DARLING HARBOUR"
       },
@@ -48,6 +50,7 @@ PLACES_QUERY_RESPONSE = {
          "id" : "cb853832ab8368db3adc52c657fe063dac0f3b11",
          "name" : "Al Ponte Harbour View Restaurant",
          "reference" : "CoQBeAAAAMQ4yYBquhcHj8qzcgUNdwgeiIOhh-Eyf21y9J58y9JXVO7yzw1mFd_wKKjEYJLR_PPjbPRGJEDFnR6eCK_zw1qwrzdyxjnM2zwvdiJ-MLwt3PxVvkkPAjLJYp1cerBc0KTyUVfBo7B4U7RFt4r3DueQ4mz6N-6G7CBoddtfRnm5EhCSGc8yi1k4EQ8whHhKfzxpGhTA1mKVV8kydhqLCsbWDitFMxqzvA",
+         "place_id": "ChIJfZmx2Jxw44kR11GqlDbYyyy",
          "types" : [ "restaurant", "food", "establishment" ],
          "vicinity" : "10 Darling Dr, Sydney CBD"
       },
@@ -62,6 +65,7 @@ PLACES_QUERY_RESPONSE = {
          "id" : "400d8b4ee30d39175f69fddfcc50590860e59d62",
          "name" : "JB's Bar at Holiday Inn Darling Harbour",
          "reference" : "CoQBfgAAACn9RQ5w_BCAcdF14KQjTh_youPZUA5a7Fbbc74gu3gWaGkl78jlDnIYuUCNOEBs4Up-iw_KrHHDRx58A91Pwqnhrf5RSMihz5gAj3M7X7IW8a_Qxl7-MuAbkoNd6rTbHXtTTWtFtKAhQBljsHPahn0kDPXXSwrhn3WjSfFQX6FfEhCWPSB0ISfYioqpCBWFveZlGhSdW7eYv0NUEAtgTAzJ7x0r4NDHPQ",
+         "place_id": "ChIJfZmx2Jxw44kR11GqlDbYzzz",
          "types" : [ "restaurant", "food", "establishment" ],
          "vicinity" : "Furama Hotel, 68 Harbour Street, Darling Harbour, Sydney"
       },
@@ -76,6 +80,7 @@ PLACES_QUERY_RESPONSE = {
          "id" : "f12a10b450db59528c18e57dea9f56f88c65c2fa",
          "name" : "Health Harbour",
          "reference" : "CnRlAAAA97YiSpT9ArwBWRZ_7FeddhMtQ4rGTy9v277_B4Y3jxUFKkZVczf3YHrhSLGuKugNQQpCDMWjYKv6LkSA8CiECzh5z7B2wOMkhn0PGjpq01p0QRapJuA6z9pQFS_oTeUq0M_paSCQ_GEB8A5-PpkJXxIQHAuoj0nyrgNwjLtByDHAgBoUdHaA6D2ceLp8ga5IJqxfqOnOwS4",
+         "place_id": "ChIJfZmx2Jxw44kR11GqlDbYmmm",
          "types" : [ "food", "store", "establishment" ],
          "vicinity" : "Darling Harbour"
       }
@@ -91,6 +96,7 @@ AUTOCOMPLETE_QUERY_RESPONSE = {
             'matched_substrings': [{'length': 6, 'offset': 0}],
             'place_id': 'ChIJSbQCipNmZIgRm4c6Nz9sGaE',
             'reference': 'CmRWAAAAqGYRANjgide_-pBFmUnaOY-m5Cy0RV8by6-pDkB_FsqouiehU-j-dV6oAdZuoMueEvKAqE1FAXcNivsB0mx9a40EEpPOXKKSiag_8wuFAlwGpeQUoXwn_ccF5zs6vldhEhAm161WaDqwSfBFKqjRE04vGhS3BcwJ2MeUbpuPbtVTUx3w3OEpLQ',
+            "place_id": "ChIJfZmx2Jxw44kR11GqlDbYnnn",
             'terms': [
                 {'offset': 0, 'value': u"Hattie B's Hot Chicken"},
                 {'offset': 24, 'value': '19th Avenue South'},
@@ -106,6 +112,7 @@ AUTOCOMPLETE_QUERY_RESPONSE = {
             'matched_substrings': [{'length': 6, 'offset': 0}],
             'place_id': 'ChIJ3yio1UncnIgRyrUcLZK_sXQ',
             'reference': 'CkQ2AAAAwRcCnvJl5ZvhsZ6TxUrkpDqPIW7mVIANGti65-SK7MlCNEPj7vGkN2Dh_KnxI7XI6pyDcTsXCoi7wLnQrr4H7xIQ_D35yzn61ZNmQelYcjk9xBoUsgP8yimN1xd9J4L6k4b6ZpK_E94',
+            "place_id": "ChIJfZmx2Jxw44kR11GqlDbYooo",
             'terms': [
                 {'offset': 0, 'value': 'Hattiesburg'},
                 {'offset': 13, 'value': 'MS'},
@@ -119,6 +126,7 @@ AUTOCOMPLETE_QUERY_RESPONSE = {
             'matched_substrings': [{'length': 6, 'offset': 0}],
             'place_id': 'ChIJXzft89tnZIgRm0ovqWZebMs',
             'reference': 'ClRMAAAAVe4DIy63p4YGFHVQpmlrgBXkA1K0T6xZbWm2SHitS28bZcPl2ctmi7QNKR2EX_2RNY5ckfPVIBL3iDOmhzjeuCrn48qNnoE0z9QJzskfdnASEKo5EvKlKYNuqep4dyThEDcaFFYegROsLxF0tssPzZAYyL9ra70z',
+            "place_id": "ChIJfZmx2Jxw44kR11GqlDbYppp",
             'terms': [
                 {'offset': 0, 'value': 'Hattie Cotton Elementary School'},
                 {'offset': 33, 'value': 'Nashville'},
@@ -133,6 +141,7 @@ AUTOCOMPLETE_QUERY_RESPONSE = {
             'matched_substrings': [{'length': 6, 'offset': 0}],
             'place_id': 'EixIYXR0aWUgQ3QsIEhlbmRlcnNvbnZpbGxlLCBUTiwgVW5pdGVkIFN0YXRlcw',
             'reference': 'CjQwAAAA16vktOVr7wLMig9H8Eb0CQFaDuIhqsG-3G7YCH7NE9qKxImG9p8W_mXbhjnkg9f4EhA6hP-p7r4I-iBMu6vcpb2VGhRFB4IPb0QupUlhD_B-Q8T6UJ8NQQ',
+            "place_id": "ChIJfZmx2Jxw44kR11GqlDbYqqq",
             'terms': [
                 {'offset': 0, 'value': 'Hattie Ct'},
                 {'offset': 11, 'value': 'Hendersonville'},
@@ -147,6 +156,7 @@ AUTOCOMPLETE_QUERY_RESPONSE = {
             'matched_substrings': [{'length': 6, 'offset': 0}],
             'place_id': 'ChIJjTUp5w2izYcRwRTy8ZpwjkI',
             'reference': 'CkQ2AAAA-9G9z7Y3SSTPJOxNcCSVhUxeaC7OTL_ADLq00_WXSHBhXi1PTsm08gX2Zz_uLnLTBFJhqxm4g9HrbTO8Rm25lBIQepnjuQ02A6BqH2lNVjsIzRoUM_ndW4AhrGZFxnKOWSAPWfAm7hY',
+            "place_id": "ChIJfZmx2Jxw44kR11GqlDbYrrr",
             'terms': [
                 {'offset': 0, 'value': 'Hattieville'},
                 {'offset': 13, 'value': 'AR'},

--- a/googleplaces/tests/tests.py
+++ b/googleplaces/tests/tests.py
@@ -6,6 +6,7 @@ Unit tests for google places.
 
 from random import randint
 import unittest
+import warnings
 
 from googleplaces import (
     GooglePlaces,
@@ -34,9 +35,17 @@ class Test(unittest.TestCase):
         place_index = randint(0, len(query_result.places)-1)
         place = query_result.places[place_index]
         response_place_entity = PLACES_QUERY_RESPONSE['results'][place_index]
-        self.assertEqual(place.id, response_place_entity.get('id'), 'ID value is incorrect.')
-        self.assertEqual(
-                         place.reference,
+
+        # make sure Place.id and Place.reference raise appropriate warnings
+        with warnings.catch_warnings(record=True) as w:
+            place_id = place.id
+            place_reference = place.reference
+            self.assertEqual(len(w), 2)
+            self.assertEqual(w[0].category, FutureWarning)
+            self.assertEqual(w[1].category, FutureWarning)
+
+        self.assertEqual(place_id, response_place_entity.get('id'), 'ID value is incorrect.')
+        self.assertEqual(place_reference,
                          response_place_entity.get('reference'),
                          'Reference value is incorrect.')
         self.assertEqual(place.name, response_place_entity.get('name'),


### PR DESCRIPTION
Hi Sam - thanks for this library, it came in handy for a project I'm working on.  While working, I made a quick change to use `place_id` instead of `id` or `reference`, and wanted to push those changes back.

Quick notes:
* Added a `@property` field for `place_id`.
* The `id` and `reference` attrs are allegedly no longer going to be present starting this summer.  It's probably a good idea to break hard if a user expects those in (old) code, but for now we just introduce a [default empty string](https://github.com/slimkrazy/python-google-places/compare/master...isms:placeid?expand=1#diff-1b986c971a80da4eb17268b178c160f5R759) like many of the other fields.
* Add deprecation `FutureWarning` for these breaking changes.  `DeprecationWarning` is [ignored by default](https://docs.python.org/2/library/warnings.html#warning-categories), hopefully `FutureWarning` will notify people if their code needs to be changed.
* Add (fake) `place_id`s to the test fixtures.
* Add some assertions to make sure the right warnings were raised.

Also used `place_id` for `check_in` and `get_details`.  It appears to work for `get_details` but maybe you can help vet the `check_in`... I wasn't using that feature and didn't find it in the API.

Tests pass:
```
..
----------------------------------------------------------------------
Ran 2 tests in 0.000s

OK
```