### PR TITLE
Fixed constant spelling (fixes #67)

### DIFF
--- a/googleplaces/types.py
+++ b/googleplaces/types.py
@@ -138,7 +138,7 @@ TYPE_TRANSIT_STATION = 'transit_station'
 
 # autocomplete types
 AC_TYPE_GEOCODE = 'geocode'
-AC_TYPE_ADDDRESS = 'address'
+AC_TYPE_ADDRESS = 'address'
 AC_TYPE_ESTABLISHMENT = 'establishment'
 AC_TYPE_REGIONS = '(regions)'
 AC_TYPE_CITIES = '(cities)'


### PR DESCRIPTION
Renamed AC_TYPE_ADDDRESS to AC_TYPE_ADDRESS.