### PR TITLE
Add new GooglePlacesAPIError for status code

### DIFF
--- a/googleplaces/__init__.py
+++ b/googleplaces/__init__.py
@@ -161,11 +161,18 @@ def _validate_response(url, response):
                                   GooglePlaces.RESPONSE_STATUS_ZERO_RESULTS]:
         error_detail = ('Request to URL %s failed with response code: %s' %
                         (url, response['status']))
-        raise GooglePlacesError(error_detail)
+        raise GooglePlacesAPIError(url, response['status'], error_detail)
 
 
 class GooglePlacesError(Exception):
     pass
+
+
+class GooglePlacesAPIError(GooglePlacesError):
+    def __init__(self, url, status_code, *args):
+        super(GooglePlacesAPIError, self).__init__(*args)
+        self.url = url
+        self.status_code = status_code
 
 
 class GooglePlacesAttributeError(AttributeError):


### PR DESCRIPTION
Per issue #81, added a new `GooglePlacesAPIError` to allow including `url` and `status_code` attributes that can be used by client code for better error handling. Went the route of a new, extending exception to avoid any issues with extra-party uses of the existing `GooglePlacesError`.