### PR TITLE
made formatted_address not require calling get_details()

### DIFF
--- a/googleplaces/__init__.py
+++ b/googleplaces/__init__.py
@@ -134,7 +134,7 @@ def _get_place_details(place_id, api_key, sensor=False,
                                               {'placeid': place_id,
                                                'sensor': str(sensor).lower(),
                                                'key': api_key,
-                                               'fields': 'formatted_address,geomery,name,place_id,types',
+                                               'fields': 'address_components,formatted_address,geomery,name,place_id,types',
                                                'language': language})
     _validate_response(url, detail_response)
     return detail_response['result']

--- a/googleplaces/__init__.py
+++ b/googleplaces/__init__.py
@@ -106,7 +106,7 @@ def geocode_location(location, sensor=False, api_key=None):
     location -- A human-readable location, e.g 'London, England'
     sensor   -- Boolean flag denoting if the location came from a device using
                 its' location sensor (default False)
-    api_key  -- A valid Google Places API key. 
+    api_key  -- A valid Google Places API key.
 
     raises:
     GooglePlacesError -- if the geocoder fails to find a location.
@@ -234,7 +234,7 @@ class GooglePlaces(object):
                sensor=False, type=None, types=[], pagetoken=None):
         """Perform a nearby search using the Google Places API.
 
-        One of either location, lat_lng or pagetoken are required, the rest of 
+        One of either location, lat_lng or pagetoken are required, the rest of
         the keyword arguments are optional.
 
         keyword arguments:
@@ -262,8 +262,8 @@ class GooglePlaces(object):
                     Places (default []). If there is only one item the request
                     will be send as type param.
         pagetoken-- Optional parameter to force the search result to return the next
-                    20 results from a previously run search. Setting this parameter 
-                    will execute a search with the same parameters used previously. 
+                    20 results from a previously run search. Setting this parameter
+                    will execute a search with the same parameters used previously.
                     (default None)
         """
         if location is None and lat_lng is None and pagetoken is None:
@@ -309,7 +309,7 @@ class GooglePlaces(object):
                     radius=3200, type=None, types=[], location=None, pagetoken=None):
         """Perform a text search using the Google Places API.
 
-        Only the one of the query or pagetoken kwargs are required, the rest of the 
+        Only the one of the query or pagetoken kwargs are required, the rest of the
         keyword arguments are optional.
 
         keyword arguments:
@@ -318,8 +318,8 @@ class GooglePlaces(object):
         location -- A human readable location, e.g 'London, England'
                     (default None)
         pagetoken-- Optional parameter to force the search result to return the next
-                    20 results from a previously run search. Setting this parameter 
-                    will execute a search with the same parameters used previously. 
+                    20 results from a previously run search. Setting this parameter
+                    will execute a search with the same parameters used previously.
                     (default None)
         radius   -- The radius (in meters) around the location/lat_lng to
                     restrict the search to. The maximum is 50000 meters.
@@ -833,6 +833,7 @@ class Place(object):
         self._id = place_data.get('id', '')
         self._reference = place_data.get('reference', '')
         self._name = place_data.get('name','')
+        self._formatted_address = place_data.get('formatted_address', '')
         self._vicinity = place_data.get('vicinity', '')
         self._geo_location = place_data['geometry']['location']
         self._rating = place_data.get('rating','')
@@ -919,6 +920,19 @@ class Place(object):
         return self._name
 
     @property
+    def formatted_address(self):
+        """Returns a string containing the human-readable address of this place.
+
+        Often this address is equivalent to the "postal address," which
+        sometimes differs from country to country. (Note that some countries,
+        such as the United Kingdom, do not allow distribution of complete postal
+        addresses due to licensing restrictions.)
+        """
+        if self._formatted_address == '' and self.details != None and 'formatted_address' in self.details:
+            self._formatted_address = self.details['formatted_address']
+        return self._formatted_address
+
+    @property
     def vicinity(self):
         """Returns a feature name of a nearby location.
 
@@ -946,18 +960,6 @@ class Place(object):
         """Returns the JSON response from Google Places Detail search API."""
         self._validate_status()
         return self._details
-
-    @property
-    def formatted_address(self):
-        """Returns a string containing the human-readable address of this place.
-
-        Often this address is equivalent to the "postal address," which
-        sometimes differs from country to country. (Note that some countries,
-        such as the United Kingdom, do not allow distribution of complete postal
-        addresses due to licensing restrictions.)
-        """
-        self._validate_status()
-        return self.details.get('formatted_address')
 
     @property
     def local_phone_number(self):

--- a/googleplaces/__init__.py
+++ b/googleplaces/__init__.py
@@ -724,8 +724,8 @@ class Prediction(object):
         """
         Returns a list of feature types describing the given result.
         """
-        if self._types == '' and self.details != None and 'types' in self.details:
-            self._icon = self.details['types']
+        if self._types == '' and self._details != None and 'types' in self._details:
+            self._icon = self._details['types']
         return self._types
 
     # The following properties require a further API call in order to be
@@ -893,15 +893,15 @@ class Place(object):
     @property
     def icon(self):
         """Returns the URL of a recommended icon for display."""
-        if self._icon == '' and self.details != None and 'icon' in self.details:
-            self._icon = self.details['icon']
+        if self._icon == '' and self._details != None and 'icon' in self._details:
+            self._icon = self._details['icon']
         return self._icon
 
     @property
     def types(self):
         """Returns a list of feature types describing the given result."""
-        if self._types == '' and self.details != None and 'types' in self.details:
-            self._icon = self.details['types']
+        if self._types == '' and self._details != None and 'types' in self._details:
+            self._icon = self._details['types']
         return self._types
 
     @property
@@ -915,8 +915,8 @@ class Place(object):
     @property
     def name(self):
         """Returns the human-readable name of the place."""
-        if self._name == '' and self.details != None and 'name' in self.details:
-            self._name = self.details['name']
+        if self._name == '' and self._details != None and 'name' in self._details:
+            self._name = self._details['name']
         return self._name
 
     @property
@@ -928,8 +928,8 @@ class Place(object):
         such as the United Kingdom, do not allow distribution of complete postal
         addresses due to licensing restrictions.)
         """
-        if self._formatted_address == '' and self.details != None and 'formatted_address' in self.details:
-            self._formatted_address = self.details['formatted_address']
+        if self._formatted_address == '' and self._details != None and 'formatted_address' in self._details:
+            self._formatted_address = self._details['formatted_address']
         return self._formatted_address
 
     @property
@@ -939,8 +939,8 @@ class Place(object):
         Often this feature refers to a street or neighborhood within the given
         results.
         """
-        if self._vicinity == '' and self.details != None and 'vicinity' in self.details:
-            self._vicinity = self.details['vicinity']
+        if self._vicinity == '' and self._details != None and 'vicinity' in self._details:
+            self._vicinity = self._details['vicinity']
         return self._vicinity
 
     @property
@@ -949,8 +949,8 @@ class Place(object):
 
         This method will return None for places that have no rating.
         """
-        if self._rating == '' and self.details != None and 'rating' in self.details:
-            self._rating = self.details['rating']
+        if self._rating == '' and self._details != None and 'rating' in self._details:
+            self._rating = self._details['rating']
         return self._rating
 
     # The following properties require a further API call in order to be
@@ -965,18 +965,18 @@ class Place(object):
     def local_phone_number(self):
         """Returns the Place's phone number in its local format."""
         self._validate_status()
-        return self.details.get('formatted_phone_number')
+        return self._details.get('formatted_phone_number')
 
     @property
     def international_phone_number(self):
         self._validate_status()
-        return self.details.get('international_phone_number')
+        return self._details.get('international_phone_number')
 
     @property
     def website(self):
         """Returns the authoritative website for this Place."""
         self._validate_status()
-        return self.details.get('website')
+        return self._details.get('website')
 
     @property
     def url(self):
@@ -986,7 +986,7 @@ class Place(object):
         that shows detailed results about this Place to the user.
         """
         self._validate_status()
-        return self.details.get('url')
+        return self._details.get('url')
 
     @property
     def html_attributions(self):
@@ -997,7 +997,7 @@ class Place(object):
         module comments for links to the relevant url.
         """
         self._validate_status()
-        return self.details.get('html_attributions', [])
+        return self._details.get('html_attributions', [])
 
     @property
     def has_attributions(self):
@@ -1036,7 +1036,7 @@ class Place(object):
     def photos(self):
         self.get_details()
         return map(lambda i: Photo(self._query_instance, i),
-                   self.details.get('photos', []))
+                   self._details.get('photos', []))
 
     def _validate_status(self):
         if self._details is None:

--- a/googleplaces/__init__.py
+++ b/googleplaces/__init__.py
@@ -333,6 +333,7 @@ class GooglePlaces(object):
                     will be send as type param.
         """
         self._request_params = {'query': query}
+        self._request_params['fields'] = 'formatted_address,geomery,name,place_id,types'
         if lat_lng is not None or location is not None:
             lat_lng_str = self._generate_lat_lng_string(lat_lng, location)
             self._request_params['location'] = lat_lng_str
@@ -388,7 +389,6 @@ class GooglePlaces(object):
             lat_lng_str = self._generate_lat_lng_string(lat_lng, location)
             self._request_params['location'] = lat_lng_str
         self._request_params['radius'] = radius
-        self._request_params['fields'] = 'formatted_address,geomery,name,place_id,types'
         if types:
             self._request_params['types'] = types
         if len(components) > 0:

--- a/googleplaces/__init__.py
+++ b/googleplaces/__init__.py
@@ -134,6 +134,7 @@ def _get_place_details(place_id, api_key, sensor=False,
                                               {'placeid': place_id,
                                                'sensor': str(sensor).lower(),
                                                'key': api_key,
+                                               'fields': 'formatted_address,geomery,name,place_id,types',
                                                'language': language})
     _validate_response(url, detail_response)
     return detail_response['result']
@@ -387,6 +388,7 @@ class GooglePlaces(object):
             lat_lng_str = self._generate_lat_lng_string(lat_lng, location)
             self._request_params['location'] = lat_lng_str
         self._request_params['radius'] = radius
+        self._request_params['fields'] = 'formatted_address,geomery,name,place_id,types'
         if types:
             self._request_params['types'] = types
         if len(components) > 0:


### PR DESCRIPTION
text_search() returns formatted_address with the object, so I made formatted_address work the same way as vicinity (which is returned from nearby_search() but not from text_search())